### PR TITLE
BE | Create `User/PuzzlesController#update` Endpoint

### DIFF
--- a/app/controllers/api/v1/users/puzzles_controller.rb
+++ b/app/controllers/api/v1/users/puzzles_controller.rb
@@ -5,4 +5,17 @@ class Api::V1::Users::PuzzlesController < ApplicationController
     puzzle = user.puzzles.find(params[:puzzle_id])
     render json: PuzzleSerializer.new(puzzle)
   end
+
+  def update
+    user = User.find(params[:user_id])
+    puzzle = Puzzle.find(params[:puzzle_id])
+
+    puzzle.update(puzzle_params)
+    render json: PuzzleSerializer.new(puzzle)
+  end
+
+  private
+  def puzzle_params
+    params.permit(:status, :title, :description, :total_pieces, :notes, :puzzle_image_url) #did not include user_id
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,8 +7,10 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       # resources :users, only: [:show] #for ease of understanding, we will skip resoruces for now
-      get '/users/:user_id/puzzles/:puzzle_id', to: 'users/puzzles#show'
       get '/users/:user_id', to: 'users#show'
+
+      get '/users/:user_id/puzzles/:puzzle_id', to: 'users/puzzles#show'
+      patch '/users/:user_id/puzzles/:puzzle_id', to: 'users/puzzles#update'
     end
   end
 end

--- a/spec/requests/api/v1/users/puzzles_request_spec.rb
+++ b/spec/requests/api/v1/users/puzzles_request_spec.rb
@@ -131,7 +131,60 @@ RSpec.describe 'User/PuzzlesController' do
       end
     end
 
-    # context "when NOT successful" do
-    # end
+    context "when NOT successful" do
+      it 'returns an error message when user_id is invalid' do
+        puzzle_update = {
+          status: 1, #FE will send us an enum digit
+          title: "Winter Scene",
+          description: "Log Cabin and Bear",
+          total_pieces: 100, 
+          notes: "This puzzle wasn't too difficult. It's fun to do with the whole family!",
+          puzzle_image_url: "/aws/s3/bucket/for_you.com"
+        }
+
+        headers = { 'CONTENT_TYPE' => 'application/json' }
+        patch "/api/v1/users/007/puzzles/#{@puzzle_2.id}", headers:, params: JSON.generate(puzzle_update)
+
+        expect(response).to have_http_status(404)
+
+        parsed_error_data = JSON.parse(response.body, symbolize_names: true)
+
+        expect(parsed_error_data).to be_a(Hash)
+        expect(parsed_error_data.keys).to eq([:errors])
+        expect(parsed_error_data[:errors]).to be_an(Array)
+        expect(parsed_error_data[:errors][0].keys).to eq([:status, :title, :detail])
+        expect(parsed_error_data[:errors][0][:status]).to eq("404")
+        expect(parsed_error_data[:errors][0][:title]).to eq("ActiveRecord::RecordNotFound")
+        expect(parsed_error_data[:errors][0][:detail]).to eq("Couldn't find User with 'id'=007")
+      end
+
+      it 'returns an error message when puzzle_id is invalid' do
+        puzzle_update = {
+          status: 1, #FE will send us an enum digit
+          title: "Winter Scene",
+          description: "Log Cabin and Bear",
+          total_pieces: 100, 
+          notes: "This puzzle wasn't too difficult. It's fun to do with the whole family!",
+          puzzle_image_url: "/aws/s3/bucket/for_you.com"
+        }
+
+        headers = { 'CONTENT_TYPE' => 'application/json' }
+        patch "/api/v1/users/#{@user_1.id}/puzzles/007", headers:, params: JSON.generate(puzzle_update)
+
+        expect(response).to have_http_status(404)
+
+        parsed_error_data = JSON.parse(response.body, symbolize_names: true)
+
+        expect(parsed_error_data).to be_a(Hash)
+        expect(parsed_error_data.keys).to eq([:errors])
+        expect(parsed_error_data[:errors]).to be_an(Array)
+        expect(parsed_error_data[:errors][0].keys).to eq([:status, :title, :detail])
+        expect(parsed_error_data[:errors][0][:status]).to eq("404")
+        expect(parsed_error_data[:errors][0][:title]).to eq("ActiveRecord::RecordNotFound")
+        expect(parsed_error_data[:errors][0][:detail]).to eq("Couldn't find Puzzle with 'id'=007")
+      end
+
+      #REFACTOR: We could add a test to limit the integers allowed for for total_pieces. Ex: [260, 500, 1000, 1500, 2000, 3000] only? 
+    end
   end
 end


### PR DESCRIPTION
## Changes: 
- Added happy & sad path test for `User/PuzzlesController#update` endpoint
- Added route
- Added strong params

NOTE: this entire Controller & Spec file will need a refactor once all endpoints are merged. Redundancies are in both. 

NOTE: We should consider adding additional sad path tests: 
- We could add a test to limit the integers allowed for for total_pieces: [260, 500, 1000, 1500, 2000, 3000] only for example

---
This is related to #

This closes #10

[] I linted my work. (RuboCop)

[] I've updated documentation & README. (if necessary)

---
(For Fun!) Please include a link to a meme/gif of your feelings about this branch!

Link: 
![step_4](https://github.com/WWC-Hackathon-2023/missing_piece_api/assets/116964982/ec664603-7323-4227-8a3f-59abcd2a4850)
