### PR TITLE
BE | Create `UsersController#create` & `SessionsController#create`/`#destroy` for `Basic Oauth`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem "puma", "~> 5.0"
 # gem "kredis"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
+gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     base64 (0.1.1)
+    bcrypt (3.1.19)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     builder (3.2.4)
@@ -256,6 +257,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap
   capybara
   debug

--- a/app/controllers/api/v1/puzzles_controller.rb
+++ b/app/controllers/api/v1/puzzles_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::PuzzlesController < ApplicationController
+  skip_before_action :set_current_user, only: [:index]
+  
     def index
       zip_code = params[:zip_code]
       users = User.where(zip_code:) if zip_code.present?

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -1,0 +1,32 @@
+class Api::V1::SessionsController < ApplicationController
+  skip_before_action :set_current_user, only: [:create]
+  before_action :authorize, only: [:destroy]
+
+  def create
+    if params[:email].present? && params[:password].present?
+      returning_user = User.find_by(email: params[:email])
+
+      # the & is called a "safe navigation" operator 
+      # It prevent a "NoMethodError" from being raised when invoking a method on nil
+      if returning_user&.authenticate(params[:password])
+        session[:user_id] = returning_user.id
+        render json: UserSerializer.new(returning_user), status: :created
+      else
+        render json: { error: 'Invalid email or password' }, status: :unauthorized
+      end
+    else
+      render json: { error: 'Email and password are required' }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    session.delete(:user_id)
+    head :no_content
+  end
+
+
+  private
+  def authorize
+    return render json: { error: 'Not authorized' }, status: :unauthorized unless session[:user_id]
+  end
+end

--- a/app/controllers/api/v1/users/puzzles_controller.rb
+++ b/app/controllers/api/v1/users/puzzles_controller.rb
@@ -1,32 +1,25 @@
-module Api
-  module V1
-    module Users
-      class PuzzlesController < ApplicationController
-        def index
-          user = User.find(params[:user_id])
-          render json: PuzzleSerializer.new(user.puzzles)
-        end
+class Api::V1::Users::PuzzlesController < ApplicationController
+  def index
+    user = User.find(params[:user_id])
+    render json: PuzzleSerializer.new(user.puzzles)
+  end
 
-        def show
-          user = User.find(params[:user_id])
-          puzzle = user.puzzles.find(params[:puzzle_id])
-          render json: PuzzleSerializer.new(puzzle)
-        end
+  def show
+    user = User.find(params[:user_id])
+    puzzle = user.puzzles.find(params[:puzzle_id])
+    render json: PuzzleSerializer.new(puzzle)
+  end
 
-        def update
-          User.find(params[:user_id])
-          puzzle = Puzzle.find(params[:puzzle_id])
+  def update
+    User.find(params[:user_id])
+    puzzle = Puzzle.find(params[:puzzle_id])
 
-          puzzle.update(puzzle_params)
-          render json: PuzzleSerializer.new(puzzle)
-        end
+    puzzle.update(puzzle_params)
+    render json: PuzzleSerializer.new(puzzle)
+  end
 
-        private
-
-        def puzzle_params
-          params.permit(:status, :title, :description, :total_pieces, :notes, :puzzle_image_url) # did not include user_id
-        end
-      end
-    end
+  private
+  def puzzle_params
+    params.permit(:status, :title, :description, :total_pieces, :notes, :puzzle_image_url) # did not include user_id
   end
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -10,6 +10,7 @@ class Api::V1::UsersController < ApplicationController
 
   def create
     new_user = User.new(user_params)
+    new_user.format_phone_number
     if new_user.save
       # session[:user_id] = new_user.id
       render json: UserSerializer.new(new_user), status: :created

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -11,6 +11,7 @@ class Api::V1::UsersController < ApplicationController
 
   def create
     new_user = User.new(user_params)
+    new_user.email.downcase
     new_user.format_phone_number
     if new_user.save
       session[:user_id] = new_user.id

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -7,4 +7,17 @@ class Api::V1::UsersController < ApplicationController
     dashboard = User.find(params[:user_id]).find_dashboard_info
     render json: DashboardSerializer.new(dashboard)
   end
+
+  def create
+    new_user = User.new(user_params)
+    if new_user.save
+      # session[:user_id] = new_user.id
+      render json: UserSerializer.new(new_user), status: :created
+    end
+  end
+
+  private
+  def user_params
+    params.permit(:full_name, :password, :password_confirmation, :email, :zip_code, :phone_number) 
+  end
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,4 +1,5 @@
 class Api::V1::UsersController < ApplicationController
+
   def show
     render json: UserSerializer.new(User.find(params[:user_id]))
   end
@@ -12,7 +13,7 @@ class Api::V1::UsersController < ApplicationController
     new_user = User.new(user_params)
     new_user.format_phone_number
     if new_user.save
-      # session[:user_id] = new_user.id
+      session[:user_id] = new_user.id
       render json: UserSerializer.new(new_user), status: :created
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,15 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::API
+  before_action :set_current_user
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
   def record_not_found(exception)
     render json: ErrorSerializer.new(exception, 404).serializable_hash, status: :not_found # 404
+  end
+
+
+  def set_current_user
+    @current_user ||= User.find_by(id: session[:user_id])
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,9 +5,11 @@ class User < ApplicationRecord
   has_many :owner_loans, class_name: 'Loan', foreign_key: 'owner_id'
   has_many :borrower_loans, class_name: 'Loan', foreign_key: 'borrower_id'
 
-  validates_presence_of :full_name, :email, :zip_code, :phone_number
-  validates :email, :phone_number, uniqueness: true
+  validates_presence_of :full_name, :email, :zip_code, :phone_number, :password, :password_confirmation
+  validates_uniqueness_of :email, :phone_number
   validates_numericality_of :zip_code
+
+  has_secure_password
 
   # This method needs a HUGE refactor:
   def find_dashboard_info

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,10 @@ class User < ApplicationRecord
 
   has_secure_password
 
+  def format_phone_number
+    phone_number.insert(0, '(').insert(4, ')').insert(5, " ").insert(9, "-")
+  end
+
   # This method needs a HUGE refactor:
   def find_dashboard_info
     owner_loans_with_puzzle = owner_loans.includes(:puzzle).where(status: [0, 1])
@@ -22,8 +26,7 @@ class User < ApplicationRecord
         full_name: full_name,
         email: email,
         zip_code: zip_code,
-        phone_number: phone_number,
-        user_image_url: user_image_url
+        phone_number: phone_number
       },
       owner_loans: [],
       borrower_loans: []

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -5,6 +5,5 @@ class UserSerializer
   attributes :full_name,
              :email,
              :zip_code,
-             :phone_number,
-             :user_image_url
+             :phone_number
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,6 +20,12 @@ Bundler.require(*Rails.groups)
 
 module MissingPiece
   class Application < Rails::Application
+
+    # created session key:
+    config.session_store :cookie_store, key: '_missing_piece_session'
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use config.session_store, config.session_options
+
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,9 @@ Rails.application.routes.draw do
       # resources :users, only: [:show] #for ease of understanding, we will skip resoruces for now
       put '/puzzles', to: 'puzzles#index'
 
+      post '/login', to: 'sessions#create'
+      delete '/logout', to: 'sessions#destroy'
+
       get '/users/:user_id', to: 'users#show'
       get '/users/:user_id/dashboard', to: 'users#dashboard'
       post '/users', to: 'users#create'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
 
       get '/users/:user_id', to: 'users#show'
       get '/users/:user_id/dashboard', to: 'users#dashboard'
+      post '/users', to: 'users#create'
 
       get '/users/:user_id/puzzles', to: 'users/puzzles#index'
       get '/users/:user_id/puzzles/:puzzle_id', to: 'users/puzzles#show'

--- a/db/migrate/20231022055841_remove_user_image_url_from_users.rb
+++ b/db/migrate/20231022055841_remove_user_image_url_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveUserImageUrlFromUsers < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :users, :user_image_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 20_231_015_214_615) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_22_055841) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -45,7 +45,6 @@ ActiveRecord::Schema[7.0].define(version: 20_231_015_214_615) do
     t.string "email"
     t.integer "zip_code"
     t.string "phone_number"
-    t.string "user_image_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,37 +9,71 @@ require 'faker'
 
 # Create users
 10.times do
+  password = Faker::Alphanumeric.alphanumeric(number: 10, min_alpha: 3, min_numeric: 3)
+  
   User.create(
     full_name: Faker::Name.name,
-    # password_digest: BCrypt::Password.create('password'), # You may want to set a secure password here
+    password: password,
+    password_confirmation: password,
     email: Faker::Internet.email,
     zip_code: Faker::Address.zip_code,
-    phone_number: Faker::PhoneNumber.phone_number,
-    user_image_url: Faker::Avatar.image
+    phone_number: Faker::PhoneNumber.phone_number
   )
 end
 
 # Create puzzles
-10.times do
+total_pieces_options = [260, 500, 1000, 1500, 2000, 3000]
+puzzle_status_options = [0, 1, 2]
+puzzle_urls = [
+  "https://res.cloudinary.com/dwcorjdyo/image/upload/v1697953702/Wild_Beauty_mwbteq.jpg",
+  "https://res.cloudinary.com/dwcorjdyo/image/upload/v1697953702/Trailerama_rep7ob.jpg",
+  "https://res.cloudinary.com/dwcorjdyo/image/upload/v1697953701/The_Arrangement_by_Erin_Wert_xs8dae.jpg",
+  "https://res.cloudinary.com/dwcorjdyo/image/upload/v1697953701/The_Old_Tractor_utq9ji.jpg",
+  "https://res.cloudinary.com/dwcorjdyo/image/upload/v1697953701/The_Poppy_Field_aoeqvd.jpg",
+  "https://res.cloudinary.com/dwcorjdyo/image/upload/v1697953701/Readers_Paradise_yzuufl.jpg",
+  "https://res.cloudinary.com/dwcorjdyo/image/upload/v1697953701/Snowmen_sqjoi8.jpg",
+  "https://res.cloudinary.com/dwcorjdyo/image/upload/v1697953699/Ravensburger_Puzzle_b7lvkv.jpg",
+  "https://res.cloudinary.com/dwcorjdyo/image/upload/v1697953699/Sherlock_Holmes_xmi91o.jpg",
+  "https://res.cloudinary.com/dwcorjdyo/image/upload/v1697953699/Perennials_ly33vr.jpg",
+  "https://res.cloudinary.com/dwcorjdyo/image/upload/v1697953699/Flowers_Italy_by_Joseph_Stella_va3dal.jpg",
+  "https://res.cloudinary.com/dwcorjdyo/image/upload/v1697953698/In_Gooood_f1lnlq.jpg",
+  "https://res.cloudinary.com/dwcorjdyo/image/upload/v1697953698/Hummingbird_and_Flowers_re6j81.jpg",
+  "https://res.cloudinary.com/dwcorjdyo/image/upload/v1697953697/Harvest_Moon_Ball_nfmlff.jpg",
+  "https://res.cloudinary.com/dwcorjdyo/image/upload/v1697953697/Country_Farm_Life_upjwn7.jpg",
+  "https://res.cloudinary.com/dwcorjdyo/image/upload/v1697953696/country_blessings_zggvlw.jpg",
+  "https://res.cloudinary.com/dwcorjdyo/image/upload/v1697953696/Friends_in_Winter_idgv3a.jpg",
+  "https://res.cloudinary.com/dwcorjdyo/image/upload/v1697953696/Buffalo_misvis.jpg",
+  "https://res.cloudinary.com/dwcorjdyo/image/upload/v1697953696/Bird_a7i5v9.jpg",
+  "https://res.cloudinary.com/dwcorjdyo/image/upload/v1697931336/Maroon_Lake_frszdv.jpg",
+  "https://res.cloudinary.com/dwcorjdyo/image/upload/v1697931322/Durango_Silverton_pkiqbm.jpg",
+  "https://res.cloudinary.com/dwcorjdyo/image/upload/v1697931301/Mountain_Chalet_voncs7.jpg",
+  "https://res.cloudinary.com/dwcorjdyo/image/upload/v1697928739/yuhdpbgsunky4mrphza0.jpg"
+]
+
+30.times do
   Puzzle.create(
     user_id: User.pluck(:id).sample,
-    status: [0, 1, 2].sample, # Replace with your puzzle status values
     title: Faker::Lorem.words(number: 3).join(' '),
     description: Faker::Lorem.sentence,
-    total_pieces: Faker::Number.between(from: 10, to: 100),
+    total_pieces: total_pieces_options.sample,
     notes: Faker::Lorem.paragraph,
-    puzzle_image_url: Faker::Internet.url
+    puzzle_image_url: puzzle_urls.sample,
+    status: puzzle_status_options.sample
   )
 end
 
 # Create loans
-10.times do
+loan_status_options = [0, 1, 2, 3]
+
+20.times do
+  owner = User.order("RANDOM()").first # Select a random owner
+  borrower = User.order("RANDOM()").first # Select a random borrower
+  puzzle = owner.puzzles.sample # Select a puzzle owned by the owner
+
   Loan.create(
-    owner_id: User.pluck(:id).sample,
-    borrower_id: User.pluck(:id).sample,
-    puzzle_id: Puzzle.pluck(:id).sample,
-    status: [0, 1, 2].sample, # Replace with your loan status values
-    created_at: Faker::Time.between(from: 1.year.ago, to: Time.now),
-    updated_at: Faker::Time.between(from: 1.year.ago, to: Time.now)
+    owner_id: owner.id,
+    borrower_id: borrower.id,
+    puzzle_id: puzzle.id,
+    status: loan_status_options.sample
   )
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,11 +4,19 @@ FactoryBot.define do
   factory :user do
     full_name { Faker::Name.name }
     email { Faker::Internet.email }
+    password { Faker::Alphanumeric.alphanumeric(number: 10, min_alpha: 3, min_numeric: 3) } 
+
+    # Set password_confirmation to the same value as password 
+    password_confirmation { |user| user.password } 
+
     # we are using US zip codes for MVP: only 5 digits
     zip_code { Faker::Number.number(digits: 5) }
+
     # We are using US examples for the MVP: this will need to change for international usage
     # We format all phone numbers before saving them in the database
     phone_number { "(#{Faker::Number.number(digits: 3)}) #{Faker::Number.number(digits: 3)}-#{Faker::Number.number(digits: 4)}" }
-    user_image_url { Faker::Internet.url(host: 'aws-s3') }
+    
+    # Decided not to use this and go with an icon on the FE repo
+    # user_image_url { Faker::Internet.url(host: 'aws-s3') }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -57,7 +57,6 @@ RSpec.describe User, type: :model do
           email: @user_1.email,
           zip_code: @user_1.zip_code,
           phone_number: @user_1.phone_number,
-          user_image_url: @user_1.user_image_url
         }
 
         dashboard_info = @user_1.find_dashboard_info

--- a/spec/requests/api/v1/sessions_request_spec.rb
+++ b/spec/requests/api/v1/sessions_request_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe 'SessionsController' do
+  describe '#create' do
+    context 'when successful' do
+      it 'logs in a user' do
+        user = User.create(
+          full_name: "Diana Puzzler",
+          password: "PuzzleQueen1",
+          password_confirmation: "PuzzleQueen1",
+          email: "dpuzzler@myemail.com",
+          zip_code: 12345,
+          phone_number: 5550009999 
+        )
+
+        login_data = {
+          email: "dpuzzler@myemail.com",
+          password: "PuzzleQueen1"
+        }
+
+        headers = { 'CONTENT_TYPE' => 'application/json' }
+        post '/api/v1/login', headers: headers, params: JSON.generate(login_data)
+
+        expect(response).to have_http_status(201)
+
+        parsed_data = JSON.parse(response.body, symbolize_names: true)
+      end
+    end
+
+    # context 'when NOT successful' do
+    # end
+  end
+
+  describe '#destroy' do
+    context 'when successful' do
+      it 'deletes a user session' do
+        user = create(:user)
+        login_data = { email: user.email, password: user.password }
+
+        headers = { 'CONTENT_TYPE' => 'application/json' }
+        post '/api/v1/login', headers: headers, params: JSON.generate(login_data)
+
+        expect(response).to have_http_status(201)
+
+        delete '/api/v1/logout', headers: headers
+
+        expect(response).to have_http_status(204)
+
+        expect(session[:user_id]).to be_nil
+      end
+    end
+
+    # context 'when NOT successful' do
+    # end
+  end
+end

--- a/spec/requests/api/v1/sessions_request_spec.rb
+++ b/spec/requests/api/v1/sessions_request_spec.rb
@@ -42,7 +42,9 @@ RSpec.describe 'SessionsController' do
 
         expect(response).to have_http_status(201)
 
-        delete '/api/v1/logout', headers: headers
+        token = JSON.parse(response.body)['token']
+
+        delete '/api/v1/logout', headers: { 'Authorization' => "Bearer #{token}" }
 
         expect(response).to have_http_status(204)
 

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -133,4 +133,34 @@ RSpec.describe 'UsersController' do
       end
     end
   end
+
+  describe '#create' do
+    context "when successful" do
+      it 'creates a new user' do
+        new_user_info = {
+          full_name: "Nancy Puzzler",
+          password: "puzzles4fun",
+          password_confirmation: "puzzles4fun",
+          email: "nancy@my_email.com",
+          zip_code: 12345,
+          phone_number: 5553039999
+        }
+
+        headers = { 'CONTENT_TYPE' => 'application/json' }
+        post "/api/v1/users", headers:, params: JSON.generate( new_user_info)
+
+        expect(response).to have_http_status(201)
+
+        parsed_data = JSON.parse(response.body, symbolize_names: true)
+
+        # expect(parsed_data).to be_a(Hash)
+        # expect(parsed_data.keys).to eq([:data])
+        # expect(parsed_data[:data]).to be_a(Hash)
+        # expect(parsed_data[:data].keys).to eq([:id, :type, :attributes])
+      end
+    end
+
+    # context "when NOT successful" do
+    # end
+  end
 end

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -18,12 +18,11 @@ RSpec.describe 'UsersController' do
         expect(parsed_data[:data].keys).to eq([:id, :type, :attributes])
 
         expect(parsed_data[:data][:attributes]).to be_a(Hash)
-        expect(parsed_data[:data][:attributes].keys).to eq([:full_name, :email, :zip_code, :phone_number, :user_image_url])
+        expect(parsed_data[:data][:attributes].keys).to eq([:full_name, :email, :zip_code, :phone_number])
         expect(parsed_data[:data][:attributes][:full_name]).to eq(user_1.full_name)
         expect(parsed_data[:data][:attributes][:email]).to eq(user_1.email)
         expect(parsed_data[:data][:attributes][:zip_code]).to eq(user_1.zip_code)
         expect(parsed_data[:data][:attributes][:phone_number]).to eq(user_1.phone_number)
-        expect(parsed_data[:data][:attributes][:user_image_url]).to eq(user_1.user_image_url)
       end
     end
 
@@ -96,12 +95,11 @@ RSpec.describe 'UsersController' do
         expect(parsed_data[:data][:attributes].keys).to eq([:user_info, :owner_loans, :borrower_loans])
 
         expect(parsed_data[:data][:attributes][:user_info]).to be_a(Hash)
-        expect(parsed_data[:data][:attributes][:user_info].keys).to eq([:full_name, :email, :zip_code, :phone_number, :user_image_url])
+        expect(parsed_data[:data][:attributes][:user_info].keys).to eq([:full_name, :email, :zip_code, :phone_number])
         expect(parsed_data[:data][:attributes][:user_info][:full_name]).to eq(@user_1.full_name)
         expect(parsed_data[:data][:attributes][:user_info][:email]).to eq(@user_1.email)
         expect(parsed_data[:data][:attributes][:user_info][:zip_code]).to eq(@user_1.zip_code)
         expect(parsed_data[:data][:attributes][:user_info][:phone_number]).to eq(@user_1.phone_number)
-        expect(parsed_data[:data][:attributes][:user_info][:user_image_url]).to eq(@user_1.user_image_url)
         
         expect(parsed_data[:data][:attributes][:owner_loans]).to be_an(Array)
         expect(parsed_data[:data][:attributes][:owner_loans].size).to eq(3)
@@ -153,10 +151,19 @@ RSpec.describe 'UsersController' do
 
         parsed_data = JSON.parse(response.body, symbolize_names: true)
 
-        # expect(parsed_data).to be_a(Hash)
-        # expect(parsed_data.keys).to eq([:data])
-        # expect(parsed_data[:data]).to be_a(Hash)
-        # expect(parsed_data[:data].keys).to eq([:id, :type, :attributes])
+        expect(parsed_data).to be_a(Hash)
+        expect(parsed_data.keys).to eq([:data])
+        expect(parsed_data[:data]).to be_a(Hash)
+        expect(parsed_data[:data].keys).to eq([:id, :type, :attributes])
+
+        expect(parsed_data[:data][:attributes]).to be_a(Hash)
+        expect(parsed_data[:data][:attributes].keys).to eq([:full_name, :email, :zip_code, :phone_number])
+        expect(parsed_data[:data][:attributes][:full_name]).to eq(new_user_info[:full_name])
+        expect(parsed_data[:data][:attributes][:email]).to eq(new_user_info[:email])
+        expect(parsed_data[:data][:attributes][:zip_code]).to eq(new_user_info[:zip_code])
+        expect(parsed_data[:data][:attributes][:phone_number]).to eq("(555) 303-9999")
+        expect(parsed_data[:data][:attributes][:user_image_url]).to eq(new_user_info[:user_image_url])
+
       end
     end
 


### PR DESCRIPTION
## Changes: 
- Due to time limitations this PR is a mash up of many somewhat-related-things: 
    - Created `UserController#create` Endpoint
         - made phone_number formatting method cuz FE wanted it to look pretty  : ) 
    - Created `SessionsController#create` and `#destroy` Endpoints for a user to login and logout
    - Updated `seed.rb` file to use real image urls

NOTE: sad path testing is poorly lacking in this work, but for the Hackathon I'm hoping we can just get it working and come back to sad path/edge case testing

---
This is related to #12

This closes #48

[] I linted my work. (RuboCop)

[] I've updated documentation & README. (if necessary)

---
(For Fun!) Please include a link to a meme/gif of your feelings about this branch!

Link: 
![login](https://github.com/WWC-Hackathon-2023/missing_piece_api/assets/116964982/d5f116cd-aa01-45d9-bb38-f59325fd0f6d)
