### PR TITLE
BE | `Refactor` to unrestful routes for login/logout

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,8 @@ Rails.application.routes.draw do
       # resources :users, only: [:show] #for ease of understanding, we will skip resoruces for now
       put '/puzzles', to: 'puzzles#index'
 
-      post '/login', to: 'sessions#create'
-      delete '/logout', to: 'sessions#destroy'
+      post '/users/:user_id/login', to: 'sessions#create'
+      delete '/users/:user_id/logout', to: 'sessions#destroy'
 
       get '/users/:user_id', to: 'users#show'
       get '/users/:user_id/dashboard', to: 'users#dashboard'

--- a/spec/requests/api/v1/sessions_request_spec.rb
+++ b/spec/requests/api/v1/sessions_request_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'SessionsController' do
         }
 
         headers = { 'CONTENT_TYPE' => 'application/json' }
-        post '/api/v1/login', headers:, params: JSON.generate(login_data)
+        post "/api/v1/users/#{user.id}/login", headers:, params: JSON.generate(login_data)
 
         expect(response).to have_http_status(201)
         expect(session[:user_id]).to eq(user.id)
@@ -43,7 +43,7 @@ RSpec.describe 'SessionsController' do
         }
 
         headers = { 'CONTENT_TYPE' => 'application/json' }
-        post '/api/v1/login', headers:, params: JSON.generate(login_data)
+        post "/api/v1/users/#{user.id}/login", headers:, params: JSON.generate(login_data)
 
         expect(response).to have_http_status(401)
 
@@ -63,12 +63,12 @@ RSpec.describe 'SessionsController' do
         login_data = { email: user.email, password: user.password }
 
         headers = { 'CONTENT_TYPE' => 'application/json' }
-        post '/api/v1/login', headers:, params: JSON.generate(login_data)
+        post "/api/v1/users/#{user.id}/login", headers:, params: JSON.generate(login_data)
 
         expect(response).to have_http_status(201)
         expect(session[:user_id]).to eq(user.id)
 
-        delete '/api/v1/logout'
+        delete "/api/v1/users/#{user.id}/logout"
 
         expect(response).to have_http_status(204)
         expect(session[:user_id]).to be_nil
@@ -83,14 +83,14 @@ RSpec.describe 'SessionsController' do
       #   login_data = { email: user.email, password: user.password }
 
       #   headers = { 'CONTENT_TYPE' => 'application/json' }
-      #   post '/api/v1/login', headers:, params: JSON.generate(login_data)
+      #   post "/api/v1/users/#{user.id}/login", headers:, params: JSON.generate(login_data)
 
       #   expect(response).to have_http_status(201)
       #   expect(session[:user_id]).to eq(user.id)
 
-      #   delete '/api/v1/logout'
+      #   delete "/api/v1/users/007/logout"
 
-      #   expect(response).to have_http_status(???)
+      #   expect(response).to have_http_status(401)
       #   expect(session[:user_id]).to eq(user.id)
       # end
     end


### PR DESCRIPTION
## Changes: 
- Updated routes to be unrestful for easy access to user_id
    - `/api/b1/users/:user_id/login`
    - `/api/b1/users/:user_id/logout`

---
This is related to #48 

This closes #

[] I linted my work. (RuboCop)

[] I've updated documentation & README. (if necessary)

---
(For Fun!) Please include a link to a meme/gif of your feelings about this branch!

Link: 